### PR TITLE
Fix response metadata middleware

### DIFF
--- a/Sources/S3Middleware/S3RequestMiddleware.swift
+++ b/Sources/S3Middleware/S3RequestMiddleware.swift
@@ -107,7 +107,7 @@ public struct S3RequestMiddleware: AWSServiceMiddleware {
         case .buffer(_), .empty:
             var metadata : [String: String] = [:]
             for (key, value) in response.headers {
-                if key.hasPrefix("x-amz-meta-"), let value = value as? String {
+                if key.lowercased().hasPrefix("x-amz-meta-"), let value = value as? String {
                     let keyWithoutPrefix = key.dropFirst("x-amz-meta-".count)
                     metadata[String(keyWithoutPrefix)] = value
                 }


### PR DESCRIPTION
RFC of HTTP headers says that they are case insensitive so it would be nice to allow both `x-amz-meta-` and `X-Amz-Meta-` to be valid prefixes in this middleware.